### PR TITLE
feat: support block suggestion

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,6 +67,9 @@ class InlineSuggestionWidget extends WidgetType {
     div.textContent = this.suggestion;
     return div;
   }
+  get lineBreaks() {
+    return this.suggestion.split('\n').length - 1;
+  }
 }
 
 type InlineFetchFn = (state: EditorState) => Promise<string>;


### PR DESCRIPTION
According to discussion in https://discuss.codemirror.net/t/implement-a-code-hinting-style-in-codemirror-6-similar-to-the-github-copilot-extension-in-vscode/6058/5 , we can use `lineBreaks` to support block suggestion.

Preview:

![screenshot-20231213-180404](https://github.com/saminzadeh/codemirror-extension-inline-suggestion/assets/1284531/ce94c117-05fa-46d8-a5cd-6fe67f7f3f3d)


Usage:
```js
import CodeMirror from '@uiw/react-codemirror';
import { inlineSuggestion } from 'codemirror-extension-inline-suggestion';

const fetchSuggestion = async (state) => {
  // or make an async API call here based on editor state
  return `hello\njavascript\nworld`;
};

function App() {
  return (
    <CodeMirror
      value=""
      height="200px"
      extensions={[
        inlineSuggestion({
          fetchFn: inlineSuggestion,
          delay: 1000,
        }),
      ]}
    />
  );
}

export default App;
```